### PR TITLE
Fix argument passing in npm start script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "confluence-to-markdown",
-  "version": "1.1.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "confluence-to-markdown",
-      "version": "1.1.2",
+      "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
         "cheerio": "^0.22.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "confluence-to-markdown",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "author": "Martin Lukes, K",
   "license": "MIT",
   "description": "Convert Confluence Pages to Markdown",
@@ -33,8 +33,8 @@
     "typescript": "^3.5.1"
   },
   "scripts": {
-    "start": "npx tsc-watch --onsuccess \"node dist/index.js\"",
-    "build": "npx tsc-watch",
+    "build": "npx tsc",
+    "start": "npm run build && node dist/index.js",
     "test": "npx jest --watchAll"
   }
 }


### PR DESCRIPTION
**Description**:

While attempting to use the `confluence-to-markdown` converter with arguments, I encountered an error due to how the scripts in `package.json` handle argument passing. Specifically, when running:

```sh
npm run start ~/Downloads/smoke-testing-guide-html/
```

I received the following error:

```
error TS6231: Could not resolve the path '/Users/jonathan.mohrbacher/Downloads/smoke-testing-guide-html/' with the extensions: '.ts', '.tsx', '.d.ts'.
```

**Cause:**

The issue arises because the arguments after `npm run start ` are being passed to `npx tsc-watch` in the `start` script, not to `node dist/index.js` as intended. The `start` script in `package.json` is defined as:

```json
"start": "npx tsc-watch --onsuccess \"node dist/index.js\"",
```

When `npm run start` is executed with arguments, those arguments are sent to `npx tsc-watch`. Since `tsc-watch` does not expect these arguments, it results in the error shown above.

**Solution:**

To resolve this issue, I updated the `build` and `start` scripts in `package.json` to ensure that arguments are correctly passed to the application rather than to `tsc-watch`.

**Changes Made:**

1. **Modified the `build` script** to compile the TypeScript code without watching:

   ```diff
   - "build": "npx tsc-watch",
   + "build": "npx tsc",
   ```

2. **Updated the `start` script** to first run the build and then execute the compiled JavaScript, ensuring the arguments are passed to `node`:

   ```diff
   - "start": "npx tsc-watch --onsuccess \"node dist/index.js\"",
   + "start": "npm run build && node dist/index.js",
   ```

**Result:**

With these changes, running the converter works as expected:

```sh
npm run start ~/Downloads/smoke-testing-guide-html/ ~/output-directory/
```

The arguments are now correctly passed to `node dist/index.js`, and the converter executes without errors.

**Conclusion:**

These modifications improve the usability of the `confluence-to-markdown` converter by ensuring that command-line arguments are handled correctly, allowing users to specify input and output paths without encountering errors.

Thank you for considering this pull request! Please let me know if there are any questions or further adjustments needed.
