### PR TITLE
Fix: Correctly select only `<head><title>` in `Page.getHeading`

### DIFF
--- a/src/Page.ts
+++ b/src/Page.ts
@@ -59,7 +59,10 @@ export class Page {
   }
 
   getHeading() {
-    const title = this.content.find('title').text();
+    // Select only the <title> tag that is a direct child of the <head> tag
+    const titleElement = this.content.find("head > title");
+    // Ensure only one title is found, and get its text, then trim
+    const title = titleElement.first().text().trim();
     if (this.fileName === 'index.html') {
       return title;
     } else {


### PR DESCRIPTION
The previous `find('title')` selector was too broad and could incorrectly include text from `<body>` elements (like `<pre>` tags containing `<title>`). This led to corrupted headings, invalid filenames, and errors during file writing and pandoc execution (`ENOENT`, `bad substitution`).

This change updates the selector to the more specific `head > title` to ensure only the actual page title element is selected, resolving the filename generation issues.